### PR TITLE
fix: provide full path to AL2023GameliftUE5sdk.zip at the end of the buildbinaries script

### DIFF
--- a/building-gamelift-server-sdk-for-unreal-engine-and-amazon-linux/buildbinaries.sh
+++ b/building-gamelift-server-sdk-for-unreal-engine-and-amazon-linux/buildbinaries.sh
@@ -4,4 +4,4 @@ echo "Building the Unreal GameLift Server SDK binaries for Amazon Linux 2023..."
 docker buildx build --platform=linux/amd64 --output=./ --target=server .
 echo "Done, now zipping the content.."
 zip -r AL2023GameliftUE5sdk.zip lib*
-echo "Done! Select Actions -> Download File and type AL2023GameliftUE5sdk.zip to download the binaries."
+echo "Done! Select Actions -> Download File and type $(pwd)/AL2023GameliftUE5sdk.zip to download the binaries."


### PR DESCRIPTION
*Issue #, if available:* #19 

*Description of changes:*

This change ensures that at the end of the buildbinaries.sh script, the full path to the AL2023GameliftUE5sdk.zip file is echoed wherever it may be located. Without the full path, the file can't be downloaded through CloudShell.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
