### PR TITLE
fix: do not install openssl and openssl-devel when building Unreal Plugin in Docker

### DIFF
--- a/building-gamelift-server-sdk-for-unreal-engine-and-amazon-linux/Dockerfile
+++ b/building-gamelift-server-sdk-for-unreal-engine-and-amazon-linux/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:latest as build-server
 
 # Install dependencies
-RUN yum install -y gcc-c++ gdb cmake3 git wget openssl openssl-devel tar perl sudo
+RUN yum install -y gcc-c++ gdb cmake3 git wget tar perl sudo
 
 # Install correct OpenSSL version. NOTE: You might need to change this based on your Unreal Engine 5 version and the OpenSSL version it utilizes
 RUN wget https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1n.tar.gz && \


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This PR ensures that when building the GameLift Server SDK for Unreal Engine on Amazon Linux, openssl and openssl-devel packages aren't installed. These packages could inadvertently end up being linked/compiled against, which could potentially cause issues if the OpenSSL version needed by Unreal Engine that's downloaded on line 7 has a different API/ABI.

I have tested that with these packages removed, the plugin still builds correctly on a clean Docker environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
