### PR TITLE
fix: add gitignore to unreal plugin tool that ignores all generated artifacts

### DIFF
--- a/building-gamelift-server-sdk-for-unreal-engine-and-amazon-linux/.gitignore
+++ b/building-gamelift-server-sdk-for-unreal-engine-and-amazon-linux/.gitignore
@@ -1,0 +1,7 @@
+# Ignore all files created by `buildbinaries.sh`:
+include/
+cmake/
+libaws-cpp-sdk-gamelift-server.so
+AL2023GameliftUE5sdk.zip
+libcrypto.so*
+libssl.so*


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This PR adds a gitignore to the "Building Amazon GameLift Server SDK for Unreal Engine and Amazon Linux" sample that ensures that all generated artifacts are ignored by Git. Whilst not strictly needed when running it in CloudShell, this is useful for developers that work on the tool on their own systems to ensure they don't accidentally commit any generated files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
