### PR TITLE
Scope down permissions for fast build tool log files

### DIFF
--- a/fast-build-update-tool/internal/config/logger.go
+++ b/fast-build-update-tool/internal/config/logger.go
@@ -70,7 +70,7 @@ func (a *ApplicationLogger) initializeSlog(verbose bool) (err error) {
 	if verbose {
 		if a.logFile == nil {
 			// If we have verbose logs, use the default slog.TextHandler, and write everything to STDOUT, and a log file
-			a.logFile, err = os.OpenFile(filepath.Join(a.logsDir, logFileName), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+			a.logFile, err = os.OpenFile(filepath.Join(a.logsDir, logFileName), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 			if err != nil {
 				return fmt.Errorf("error creating log file %w", err)
 			}

--- a/fast-build-update-tool/internal/tools/ssh_command_runner.go
+++ b/fast-build-update-tool/internal/tools/ssh_command_runner.go
@@ -66,7 +66,7 @@ func (s *SSHCommandRunner) Run(ctx context.Context, remotePublicKey ssh.PublicKe
 
 	logFilePath := config.GetLogPathForFile(fmt.Sprintf("%s-ssh-command.log", s.instanceId))
 	// Set up a log file so we log out any remote output we get from the instance
-	logFile, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE, 0666)
+	logFile, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return fmt.Errorf("error creating log file for ssh command runner: %w", err)
 	}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Scope down log file permissions to 0644. 

*Description of testing and validations of changes:* Ran fast build tool to modify game server build on fleet and verified logs are written properly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
