### PR TITLE
Add round-robin communication and get-player-connection-details command to player-gateway-testing-app to amazon-gamelift/develop

### DIFF
--- a/player-gateway-testing-app/README.md
+++ b/player-gateway-testing-app/README.md
@@ -17,6 +17,7 @@ A UDP relay testing tool for validating Amazon GameLift Servers player gateway i
 - [Runtime configuration](#runtime-configuration)
   - [set-degradation](#set-degradation)
   - [replace-token](#replace-token)
+  - [get-player-connection-details](#get-player-connection-details)
 - [How it works](#how-it-works)
   - [Traffic flow](#traffic-flow)
 - [Testing](#testing)
@@ -97,7 +98,7 @@ On startup, the app will log the list of client-side endpoints. The game clients
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--testing-app-ip` | `-i` | `127.0.0.1` | IP address for the testing app to listen on |
-| `--udp-endpoint-count` | `-u` | `3` | Number of UDP endpoints (1-10) |
+| `--udp-endpoint-count` | `-u` | `3` | Number of UDP endpoints per player (1-10) |
 | `--tool-port-range` | `-r` | (auto-generated) | Port range for allocation: `<start>-<end>` |
 | `--player-count` | `-n` | `1` | Number of players (1 token is generated per player) |
 | `--report-file-path` | `-f` | `./report.txt` | Path for invalid packet reports |
@@ -113,12 +114,11 @@ Basic usage with custom endpoint count:
   --udp-endpoint-count 5
 ```
 
-With token validation and custom port range:
+With custom port range:
 ```bash
 ./player-gateway-testing-app \
   --game-server-ip game.example.com \
   --game-server-port 9000 \
-  --token "MySecretToken" \
   --tool-port-range 10000-10100
 ```
 
@@ -159,13 +159,41 @@ Generate a new token and replace the existing token for a specific player. The o
 
 ```bash
 ./player-gateway-testing-app replace-token \
-  --player-number 1 \
-  --port 8000
+  --player-number 1
 ```
 
 Flags:
 - `--player-number`: The player number (required)
 - `--port`: Any port of the running testing app (default: 8000)
+
+### get-player-connection-details
+
+Get connection details for specified players. This simulates the GetPlayerConnectionDetails API and returns the token and endpoints for each player.
+
+```bash
+./player-gateway-testing-app get-player-connection-details \
+  --player-numbers 1,2,3
+```
+
+Flags:
+- `--player-numbers`: Comma-separated list of player numbers (required)
+- `--port`: Any port of the running testing app (default: 8000)
+
+Example output:
+```json
+[
+  {
+    "PlayerNumber": "1",
+    "Endpoints": [
+      {"IpAddress": "127.0.0.1", "Port": 8000},
+      {"IpAddress": "127.0.0.1", "Port": 8001},
+      {"IpAddress": "127.0.0.1", "Port": 8002}
+    ],
+    "PlayerGatewayToken": "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMg==",
+    "Expiration": 1700000000
+  }
+]
+```
 
 ## Testing
 

--- a/player-gateway-testing-app/cmd/flags.go
+++ b/player-gateway-testing-app/cmd/flags.go
@@ -45,7 +45,7 @@ func validateIPAddress(ipAddress string) error {
 	return nil
 }
 
-func validatePortRange(portRange string, endpointCount int) error {
+func validatePortRange(portRange string, endpointCount, playerCount int) error {
 	if portRange == "" {
 		return nil
 	}
@@ -67,10 +67,11 @@ func validatePortRange(portRange string, endpointCount int) error {
 		return fmt.Errorf("end port of %s out of bounds: %w", ToolPortRangeFlag, err)
 	}
 
+	totalEndpoints := endpointCount * playerCount
 	availablePorts := endPort - startPort + 1
-	if availablePorts < endpointCount {
-		return fmt.Errorf("insufficient ports in range %s for %d UDP endpoints (need %d, have %d)",
-			portRange, endpointCount, endpointCount, availablePorts)
+	if availablePorts < totalEndpoints {
+		return fmt.Errorf("insufficient ports in range %s for %d players with %d endpoints each (need %d, have %d)",
+			portRange, playerCount, endpointCount, totalEndpoints, availablePorts)
 	}
 
 	return nil
@@ -94,7 +95,7 @@ func validateFlags() error {
 		return fmt.Errorf("%s out of bounds: %w", ServerPortFlag, err)
 	}
 
-	if err := validatePortRange(cfg.PortRange, cfg.UDPEndpointCount); err != nil {
+	if err := validatePortRange(cfg.PortRange, cfg.UDPEndpointCount, cfg.PlayerCount); err != nil {
 		return err
 	}
 

--- a/player-gateway-testing-app/cmd/flags_test.go
+++ b/player-gateway-testing-app/cmd/flags_test.go
@@ -133,20 +133,23 @@ func TestValidatePortRange(t *testing.T) {
 		name             string
 		portRange        string
 		udpEndpointCount int
+		playerCount      int
 		wantErr          bool
 	}{
-		{"valid range", "8000-9000", 3, false},
-		{"empty string", "", 3, false},
-		{"invalid format", "invalid-range", 3, true},
-		{"start port too high", "70000-80000", 3, true},
-		{"end port too high", "8000-70000", 3, true},
-		{"start greater than end", "9000-8000", 3, true},
-		{"range too small", "9000-9001", 10, true},
+		{"valid range", "8000-9000", 3, 1, false},
+		{"empty string", "", 3, 1, false},
+		{"invalid format", "invalid-range", 3, 1, true},
+		{"start port too high", "70000-80000", 3, 1, true},
+		{"end port too high", "8000-70000", 3, 1, true},
+		{"start greater than end", "9000-8000", 3, 1, true},
+		{"range too small for endpoints", "9000-9001", 10, 1, true},
+		{"range too small for players", "9000-9005", 3, 3, true},
+		{"valid range multiple players", "8000-8020", 3, 2, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validatePortRange(tt.portRange, tt.udpEndpointCount)
+			err := validatePortRange(tt.portRange, tt.udpEndpointCount, tt.playerCount)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/player-gateway-testing-app/cmd/get-player-connection-details/get_player_connection_details.go
+++ b/player-gateway-testing-app/cmd/get-player-connection-details/get_player_connection_details.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package getplayerconnectiondetails
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/amazon-gamelift/amazon-gamelift-toolkit/player-gateway-testing-app/internal/common"
+	"github.com/amazon-gamelift/amazon-gamelift-toolkit/player-gateway-testing-app/internal/proxy"
+	"github.com/spf13/cobra"
+)
+
+const (
+	playerNumbersFlag = "player-numbers"
+	portFlag          = "port"
+)
+
+var (
+	playerNumbersStr string
+	port             int
+
+	GetPlayerConnectionDetails = &cobra.Command{
+		Use:   "get-player-connection-details",
+		Short: "Get connection details for specified players",
+		RunE:  runGetPlayerConnectionDetails,
+	}
+)
+
+func init() {
+	GetPlayerConnectionDetails.Flags().StringVar(&playerNumbersStr, playerNumbersFlag, "", "Comma-separated list of player numbers (e.g., --player-numbers 1,2,3)")
+	GetPlayerConnectionDetails.Flags().IntVar(&port, portFlag, 8000, "A UDP port of the running testing app")
+	GetPlayerConnectionDetails.MarkFlagRequired(playerNumbersFlag)
+}
+
+func runGetPlayerConnectionDetails(command *cobra.Command, args []string) error {
+	if err := common.ValidateNumberWithinBounds(port, common.MinPort, common.MaxPort); err != nil {
+		return fmt.Errorf("port must be between %d and %d", common.MinPort, common.MaxPort)
+	}
+
+	playerNumbers := strings.Split(playerNumbersStr, ",")
+	if len(playerNumbers) == 1 && playerNumbers[0] == "" {
+		return fmt.Errorf("at least one player number is required")
+	}
+
+	for _, num := range playerNumbers {
+		if _, err := strconv.Atoi(strings.TrimSpace(num)); err != nil {
+			return fmt.Errorf("invalid player number: %s", num)
+		}
+	}
+
+	message := fmt.Sprintf("%s%s:%s", proxy.ConfigCommandPrefix, proxy.GetPlayerConnectionDetailsCommand, playerNumbersStr)
+	response, err := common.SendUDPMessageWithResponse(port, message)
+	if err != nil {
+		return fmt.Errorf("failed to get response from testing app: %w", err)
+	}
+
+	var result proxy.PlayerConnectionDetailsResponse
+	if err := json.Unmarshal([]byte(response), &result); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	output, err := json.MarshalIndent(result.PlayerConnectionDetails, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to format response: %w", err)
+	}
+
+	fmt.Println(string(output))
+	return nil
+}

--- a/player-gateway-testing-app/cmd/get-player-connection-details/get_player_connection_details_test.go
+++ b/player-gateway-testing-app/cmd/get-player-connection-details/get_player_connection_details_test.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package getplayerconnectiondetails
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/amazon-gamelift/amazon-gamelift-toolkit/player-gateway-testing-app/internal/assert"
+	"github.com/amazon-gamelift/amazon-gamelift-toolkit/player-gateway-testing-app/internal/proxy"
+)
+
+func TestRunGetPlayerConnectionDetails_ValidInput(t *testing.T) {
+	tests := []struct {
+		name          string
+		playerNumbers string
+	}{
+		{"single player", "1"},
+		{"multiple players", "1,2,3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup UDP listener to receive and respond
+			addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+			assert.NoError(t, err)
+
+			conn, err := net.ListenUDP("udp", addr)
+			assert.NoError(t, err)
+			defer conn.Close()
+
+			connAddr := conn.LocalAddr().(*net.UDPAddr)
+
+			// Set config values
+			playerNumbersStr = tt.playerNumbers
+			port = connAddr.Port
+
+			errChan := make(chan error, 1)
+			go func() {
+				errChan <- runGetPlayerConnectionDetails(nil, nil)
+			}()
+
+			// Read the message and send response
+			buffer := make([]byte, 1024)
+			n, clientAddr, err := conn.ReadFromUDP(buffer)
+			assert.NoError(t, err)
+
+			// Verify message format
+			expectedMessage := proxy.ConfigCommandPrefix + proxy.GetPlayerConnectionDetailsCommand + ":" + tt.playerNumbers
+			assert.Equal(t, expectedMessage, string(buffer[:n]))
+
+			// Send mock response
+			mockResponse := proxy.PlayerConnectionDetailsResponse{
+				PlayerConnectionDetails: []proxy.PlayerConnectionDetail{
+					{PlayerNumber: "1", PlayerGatewayToken: "token123", Endpoints: []proxy.PlayerConnectionEndpoint{{IpAddress: "127.0.0.1", Port: 8000}}},
+				},
+			}
+			responseBytes, _ := json.Marshal(mockResponse)
+			conn.WriteToUDP(responseBytes, clientAddr)
+
+			err = <-errChan
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestRunGetPlayerConnectionDetails_InvalidPort(t *testing.T) {
+	tests := []struct {
+		name          string
+		portValue     int
+		expectedError string
+	}{
+		{"zero port", 0, "port must be between 1 and 65535"},
+		{"negative port", -1, "port must be between 1 and 65535"},
+		{"port too high", 65536, "port must be between 1 and 65535"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			playerNumbersStr = "1"
+			port = tt.portValue
+
+			err := runGetPlayerConnectionDetails(nil, nil)
+			assert.Error(t, err)
+			assert.Equal(t, tt.expectedError, err.Error())
+		})
+	}
+}
+
+func TestRunGetPlayerConnectionDetails_InvalidPlayerNumbers(t *testing.T) {
+	tests := []struct {
+		name          string
+		playerNumbers string
+		expectedError string
+	}{
+		{"non-numeric", "abc", "invalid player number: abc"},
+		{"mixed valid and invalid", "1,abc,3", "invalid player number: abc"},
+		{"empty in list", "1,,3", "invalid player number: "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			playerNumbersStr = tt.playerNumbers
+			port = 8000
+
+			err := runGetPlayerConnectionDetails(nil, nil)
+			assert.Error(t, err)
+			assert.Equal(t, tt.expectedError, err.Error())
+		})
+	}
+}
+
+func TestRunGetPlayerConnectionDetails_EmptyPlayerNumbers(t *testing.T) {
+	tests := []struct {
+		name          string
+		playerNumbers string
+	}{
+		{"empty string", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			playerNumbersStr = tt.playerNumbers
+			port = 8000
+
+			err := runGetPlayerConnectionDetails(nil, nil)
+			assert.Error(t, err)
+			assert.Equal(t, "at least one player number is required", err.Error())
+		})
+	}
+}
+
+func TestGetPlayerConnectionDetailsCommand_FlagsInitialization(t *testing.T) {
+	assert.NotNil(t, GetPlayerConnectionDetails)
+	assert.Equal(t, "get-player-connection-details", GetPlayerConnectionDetails.Use)
+	assert.NotNil(t, GetPlayerConnectionDetails.RunE)
+
+	playerNumbersFlag := GetPlayerConnectionDetails.Flags().Lookup("player-numbers")
+	assert.NotNil(t, playerNumbersFlag)
+	assert.Equal(t, "", playerNumbersFlag.DefValue)
+
+	portFlag := GetPlayerConnectionDetails.Flags().Lookup("port")
+	assert.NotNil(t, portFlag)
+	assert.Equal(t, "8000", portFlag.DefValue)
+}

--- a/player-gateway-testing-app/cmd/root.go
+++ b/player-gateway-testing-app/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	getplayerconnectiondetails "github.com/amazon-gamelift/amazon-gamelift-toolkit/player-gateway-testing-app/cmd/get-player-connection-details"
 	replacetoken "github.com/amazon-gamelift/amazon-gamelift-toolkit/player-gateway-testing-app/cmd/replace-token"
 	setdegradation "github.com/amazon-gamelift/amazon-gamelift-toolkit/player-gateway-testing-app/cmd/set-degradation"
 	"github.com/amazon-gamelift/amazon-gamelift-toolkit/player-gateway-testing-app/internal/app"
@@ -39,6 +40,7 @@ func init() {
 
 	rootCmd.AddCommand(setdegradation.SetDegradation)
 	rootCmd.AddCommand(replacetoken.ReplaceToken)
+	rootCmd.AddCommand(getplayerconnectiondetails.GetPlayerConnectionDetails)
 }
 
 func run(cmd *cobra.Command, args []string) error {

--- a/player-gateway-testing-app/internal/app/app.go
+++ b/player-gateway-testing-app/internal/app/app.go
@@ -95,7 +95,7 @@ func (a *App) setupProxies(c config.Config) error {
 	if err != nil {
 		return err
 	}
-	a.statsCollector = stats.NewStatsCollector(a.tokenManager, startPort, c.UDPEndpointCount, c.IPAddress)
+	a.statsCollector = stats.NewStatsCollector(a.tokenManager, startPort, c.UDPEndpointCount, c.PlayerCount, c.IPAddress)
 
 	if err := a.createServerSideProxy(c); err != nil {
 		return err
@@ -153,9 +153,11 @@ func (a *App) createServerSideProxy(c config.Config) error {
 }
 
 // createClientSideProxies creates multiple client-facing proxies that accept client connections.
+// Each player gets their own set of endpoints.
 //
 // Parameters:
 //   - c: configuration containing client IP address, port range, and endpoint count
+//   - startPort: starting port number for the first player's endpoints
 //
 // Returns:
 //   - error: nil on success, error if client proxy creation fails
@@ -165,22 +167,28 @@ func (a *App) createClientSideProxies(c config.Config, startPort int) error {
 		return fmt.Errorf("unable to parse UDP address when creating client-side proxy")
 	}
 
-	a.clientSideProxies = make([]*proxy.Proxy, 0, c.UDPEndpointCount)
-	for i := range c.UDPEndpointCount {
-		port := startPort + i
+	totalEndpoints := c.UDPEndpointCount * c.PlayerCount
+	a.clientSideProxies = make([]*proxy.Proxy, 0, totalEndpoints)
 
-		csp, err := proxy.NewClientSideProxy(
-			c.IPAddress,
-			port,
-			destinationAddr,
-			a.tokenManager,
-			c.ReportFilePath,
-			a.statsCollector.GetEventChannel(),
-		)
-		if err != nil {
-			return fmt.Errorf("failed to create client-side proxy %d: %w", i+1, err)
+	port := startPort
+	for playerNum := 1; playerNum <= c.PlayerCount; playerNum++ {
+		for i := range c.UDPEndpointCount {
+			csp, err := proxy.NewClientSideProxy(
+				c.IPAddress,
+				port,
+				destinationAddr,
+				a.tokenManager,
+				playerNum,
+				c.ReportFilePath,
+				a.statsCollector.GetEventChannel(),
+				a.statsCollector.GetSnapshot,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to create client-side proxy for player %d endpoint %d: %w", playerNum, i+1, err)
+			}
+			a.clientSideProxies = append(a.clientSideProxies, csp)
+			port++
 		}
-		a.clientSideProxies = append(a.clientSideProxies, csp)
 	}
 
 	return nil
@@ -190,14 +198,16 @@ func (a *App) findClientsideProxyPortRangeStart(c config.Config) (int, error) {
 	var startPort int
 	var err error
 
+	totalEndpoints := c.UDPEndpointCount * c.PlayerCount
 	if c.PortRange == "" {
 		const defaultStartSearchPort = 8000
 		const maxSearchPort = 65535
-		startPort, err = common.FindAvailablePortRange(defaultStartSearchPort, c.UDPEndpointCount, maxSearchPort)
+		startPort, err = common.FindAvailablePortRange(defaultStartSearchPort, totalEndpoints, maxSearchPort)
 		if err != nil {
 			return 0, fmt.Errorf("failed to find available port range: %w", err)
 		}
-		log.Printf("Auto-selected port range starting at %d for %d endpoints", startPort, c.UDPEndpointCount)
+		log.Printf("Auto-selected port range starting at %d for %d players with %d endpoints each (%d total)",
+			startPort, c.PlayerCount, c.UDPEndpointCount, totalEndpoints)
 	} else {
 		startPort, _, err = common.ParsePortRange(c.PortRange)
 		if err != nil {

--- a/player-gateway-testing-app/internal/common/common.go
+++ b/player-gateway-testing-app/internal/common/common.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -105,6 +106,44 @@ func SendUDPMessage(port int, message string) error {
 	}
 
 	return nil
+}
+
+// SendUDPMessageWithResponse sends a UDP message and waits for a response.
+//
+// Parameters:
+//   - port: the port to send the message to
+//   - message: the message to send
+//
+// Returns:
+//   - string: the response received
+//   - error: nil on success, error if connection, write, or read fails
+func SendUDPMessageWithResponse(port int, message string) (string, error) {
+	const responseTimeout = 5 * time.Second
+
+	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return "", err
+	}
+
+	conn, err := net.DialUDP("udp", nil, addr)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	conn.SetReadDeadline(time.Now().Add(responseTimeout))
+
+	if _, err = conn.Write([]byte(message)); err != nil {
+		return "", err
+	}
+
+	buf := make([]byte, 65535)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return "", err
+	}
+
+	return string(buf[:n]), nil
 }
 
 // ValidateNumberWithinBounds validates that a value is within the specified bounds.

--- a/player-gateway-testing-app/internal/proxy/client_side_traffic_handler.go
+++ b/player-gateway-testing-app/internal/proxy/client_side_traffic_handler.go
@@ -27,16 +27,17 @@ const (
 	MinimumDegradationPercentage = 0
 	MaximumDegradationPercentage = 100
 
-	ConfigCommandDelimiter = ":"
-	SetDegradationCommand  = "SetDegradation"
-	ReplaceTokenCommand    = "ReplaceToken"
-	ListTokensCommand      = "ListTokens"
-	ConfigCommandPrefix    = "PlayerGateway:"
+	ConfigCommandDelimiter            = ":"
+	SetDegradationCommand             = "SetDegradation"
+	ReplaceTokenCommand               = "ReplaceToken"
+	ListTokensCommand                 = "ListTokens"
+	GetPlayerConnectionDetailsCommand = "GetPlayerConnectionDetails"
+	ConfigCommandPrefix               = "PlayerGateway:"
 )
 
 var (
 	ConfigCommandPrefixByteArray = []byte(ConfigCommandPrefix)
-	ParameterRequiringCommands   = []string{SetDegradationCommand, ReplaceTokenCommand}
+	ParameterRequiringCommands   = []string{SetDegradationCommand, ReplaceTokenCommand, GetPlayerConnectionDetailsCommand}
 )
 
 // ClientSideProxyTrafficHandler handles preprocessing and routing for client-side proxies.
@@ -44,6 +45,8 @@ type ClientSideProxyTrafficHandler struct {
 	tokenManager          *token.TokenManager
 	degradationPercentage int
 	rng                   *rand.Rand
+	expectedPlayerNumber  int   // Player number that must use this endpoint
+	requestedPlayerNumbers []int // Player numbers from GetPlayerConnectionDetails command
 }
 
 // PreprocessServerBoundTraffic processes server-bound traffic from clients.
@@ -71,6 +74,8 @@ func (c *ClientSideProxyTrafficHandler) PreprocessServerBoundTraffic(data []byte
 		switch cmdName {
 		case SetDegradationCommand:
 			return PreprocessServerBoundTrafficResult{0, nil, DegradationResult{c.degradationPercentage}}, nil
+		case GetPlayerConnectionDetailsCommand:
+			return PreprocessServerBoundTrafficResult{0, nil, GetPlayerConnectionDetailsResult{PlayerNumbers: c.requestedPlayerNumbers}}, nil
 		default:
 			return PreprocessServerBoundTrafficResult{0, nil, GenericCommandResult{}}, nil
 		}
@@ -85,6 +90,12 @@ func (c *ClientSideProxyTrafficHandler) PreprocessServerBoundTraffic(data []byte
 	if err != nil {
 		return PreprocessServerBoundTrafficResult{0, nil, nil}, fmt.Errorf("token validation failed: %w", err)
 	}
+
+	// Validate player is using their assigned endpoint
+	if playerNumber != c.expectedPlayerNumber {
+		return PreprocessServerBoundTrafficResult{0, nil, nil}, fmt.Errorf("player %d cannot use endpoint assigned to player %d", playerNumber, c.expectedPlayerNumber)
+	}
+
 	return PreprocessServerBoundTrafficResult{playerNumber, modifiedData, nil}, nil
 }
 
@@ -143,6 +154,9 @@ func (c *ClientSideProxyTrafficHandler) parseConfigCommand(data []byte) (string,
 		return SetDegradationCommand, c.setDegradation(cmdParameter)
 	case ReplaceTokenCommand:
 		return ReplaceTokenCommand, c.replaceToken(cmdParameter)
+	case GetPlayerConnectionDetailsCommand:
+		c.parsePlayerNumbers(cmdParameter)
+		return GetPlayerConnectionDetailsCommand, nil
 	case ListTokensCommand:
 		tokens := c.tokenManager.GetValidTokens()
 		for playerNum := 1; playerNum <= c.tokenManager.GetPlayerCount(); playerNum++ {
@@ -209,4 +223,21 @@ func (c *ClientSideProxyTrafficHandler) shouldDropPacket() bool {
 		return true
 	}
 	return c.rng.Intn(MaximumDegradationPercentage) < c.degradationPercentage
+}
+
+// parsePlayerNumbers parses a GetPlayerConnectionDetails command parameter.
+// Expected format: comma-separated player numbers (e.g., "1,2,3")
+//
+// Parameters:
+//   - cmdParameter: string containing comma-separated player numbers
+func (c *ClientSideProxyTrafficHandler) parsePlayerNumbers(cmdParameter string) {
+	c.requestedPlayerNumbers = nil
+	for _, numStr := range strings.Split(cmdParameter, ",") {
+		num, err := strconv.Atoi(strings.TrimSpace(numStr))
+		if err != nil {
+			log.Printf("Warning: ignoring invalid player number: %s", numStr)
+			continue
+		}
+		c.requestedPlayerNumbers = append(c.requestedPlayerNumbers, num)
+	}
 }

--- a/player-gateway-testing-app/internal/proxy/client_side_traffic_handler_test.go
+++ b/player-gateway-testing-app/internal/proxy/client_side_traffic_handler_test.go
@@ -18,7 +18,8 @@ import (
 func TestClientSideProxyTrafficHandler_PreprocessServerBoundTraffic_NormalTraffic(t *testing.T) {
 	tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 	handler := &ClientSideProxyTrafficHandler{
-		tokenManager: tokenManager,
+		tokenManager:         tokenManager,
+		expectedPlayerNumber: 1,
 	}
 
 	// Create valid token data
@@ -32,6 +33,39 @@ func TestClientSideProxyTrafficHandler_PreprocessServerBoundTraffic_NormalTraffi
 	// Verify hash was stripped but player number remains
 	expectedData := "1|" + testutil.TestMessage
 	assert.Equal(t, string(result.Data), expectedData)
+}
+
+func TestClientSideProxyTrafficHandler_PreprocessServerBoundTraffic_WrongPlayerEndpoint(t *testing.T) {
+	tokenManager := testutil.CreateTestTokenManager(2)
+	handler := &ClientSideProxyTrafficHandler{
+		tokenManager:         tokenManager,
+		expectedPlayerNumber: 2, // Endpoint assigned to player 2
+	}
+
+	// Send player 1's token to player 2's endpoint
+	player1Token := tokenManager.GetDecodedTokenForPlayer(1)
+	data := []byte(player1Token + testutil.TestMessage)
+	addr, _ := net.ResolveUDPAddr("udp", testutil.TestSourceAddr)
+
+	_, err := handler.PreprocessServerBoundTraffic(data, addr)
+	assert.Error(t, err, "Expected error when player uses wrong endpoint")
+}
+
+func TestClientSideProxyTrafficHandler_PreprocessServerBoundTraffic_CorrectPlayerEndpoint(t *testing.T) {
+	tokenManager := testutil.CreateTestTokenManager(2)
+	handler := &ClientSideProxyTrafficHandler{
+		tokenManager:         tokenManager,
+		expectedPlayerNumber: 2, // Endpoint assigned to player 2
+	}
+
+	// Send player 2's token to player 2's endpoint - should succeed
+	player2Token := tokenManager.GetDecodedTokenForPlayer(2)
+	data := []byte(player2Token + testutil.TestMessage)
+	addr, _ := net.ResolveUDPAddr("udp", testutil.TestSourceAddr)
+
+	result, err := handler.PreprocessServerBoundTraffic(data, addr)
+	assert.NoError(t, err)
+	assert.Equal(t, result.PlayerNumber, 2)
 }
 
 func TestClientSideProxyTrafficHandler_PreprocessServerBoundTraffic_ConfigCommand(t *testing.T) {
@@ -57,8 +91,9 @@ func TestClientSideProxyTrafficHandler_PreprocessServerBoundTraffic_ConfigComman
 		t.Run(tt.name, func(t *testing.T) {
 			tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 			handler := &ClientSideProxyTrafficHandler{
-				tokenManager: tokenManager,
-				rng:          rand.New(rand.NewSource(time.Now().UnixNano())),
+				tokenManager:         tokenManager,
+				expectedPlayerNumber: 1,
+				rng:                  rand.New(rand.NewSource(time.Now().UnixNano())),
 			}
 
 			addr, _ := net.ResolveUDPAddr("udp", testutil.TestSourceAddr)
@@ -73,7 +108,9 @@ func TestClientSideProxyTrafficHandler_PreprocessServerBoundTraffic_ConfigComman
 }
 
 func TestClientSideProxyTrafficHandler_HandleClientBoundTraffic(t *testing.T) {
-	handler := &ClientSideProxyTrafficHandler{}
+	handler := &ClientSideProxyTrafficHandler{
+		expectedPlayerNumber: 1,
+	}
 
 	socket := testutil.CreateTestUDPSocket(t)
 	defer socket.Close()
@@ -128,8 +165,9 @@ func TestClientSideProxyTrafficHandler_ConfigCommand_MalformedCommands(t *testin
 		t.Run(tt.name, func(t *testing.T) {
 			tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 			handler := &ClientSideProxyTrafficHandler{
-				tokenManager: tokenManager,
-				rng:          rand.New(rand.NewSource(time.Now().UnixNano())),
+				tokenManager:         tokenManager,
+				expectedPlayerNumber: 1,
+				rng:                  rand.New(rand.NewSource(time.Now().UnixNano())),
 			}
 
 			_, err := handler.parseConfigCommand([]byte(tt.command))
@@ -165,7 +203,8 @@ func TestClientSideProxyTrafficHandler_ParseConfigCommand_SetDegradation(t *test
 		t.Run(tt.name, func(t *testing.T) {
 			tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 			handler := &ClientSideProxyTrafficHandler{
-				tokenManager: tokenManager,
+				tokenManager:         tokenManager,
+				expectedPlayerNumber: 1,
 			}
 
 			cmdName, err := handler.parseConfigCommand([]byte(tt.command))
@@ -198,8 +237,9 @@ func TestClientSideProxyTrafficHandler_ParseConfigCommand_SetDegradationClamping
 		t.Run(tt.name, func(t *testing.T) {
 			tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 			handler := &ClientSideProxyTrafficHandler{
-				tokenManager: tokenManager,
-				rng:          rand.New(rand.NewSource(time.Now().UnixMicro())),
+				tokenManager:         tokenManager,
+				expectedPlayerNumber: 1,
+				rng:                  rand.New(rand.NewSource(time.Now().UnixMicro())),
 			}
 
 			handler.parseConfigCommand([]byte(tt.command))
@@ -232,8 +272,9 @@ func TestClientSideProxyTrafficHandler_ParseConfigCommand_SetDegradationInvalidP
 		t.Run(tt.name, func(t *testing.T) {
 			tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 			handler := &ClientSideProxyTrafficHandler{
-				tokenManager: tokenManager,
-				rng:          rand.New(rand.NewSource(time.Now().UnixNano())),
+				tokenManager:         tokenManager,
+				expectedPlayerNumber: 1,
+				rng:                  rand.New(rand.NewSource(time.Now().UnixNano())),
 			}
 
 			_, err := handler.parseConfigCommand([]byte(tt.command))
@@ -285,8 +326,9 @@ func TestClientSideProxyTrafficHandler_ParseConfigCommand_ReplaceToken(t *testin
 		t.Run(tt.name, func(t *testing.T) {
 			tokenManager := token.NewTokenManager(tt.playerCount)
 			handler := &ClientSideProxyTrafficHandler{
-				tokenManager: tokenManager,
-				rng:          rand.New(rand.NewSource(time.Now().UnixNano())),
+				tokenManager:         tokenManager,
+				expectedPlayerNumber: 1,
+				rng:                  rand.New(rand.NewSource(time.Now().UnixNano())),
 			}
 
 			cmdName, err := handler.parseConfigCommand([]byte(tt.command))
@@ -328,6 +370,7 @@ func TestClientSideProxyTrafficHandler_DegradationDropping(t *testing.T) {
 			tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 			handler := &ClientSideProxyTrafficHandler{
 				tokenManager:          tokenManager,
+				expectedPlayerNumber:  1,
 				rng:                   rand.New(rand.NewSource(time.Now().UnixMicro())),
 				degradationPercentage: tt.degradationPercentage,
 			}
@@ -381,6 +424,7 @@ func TestClientSideProxyTrafficHandler_DegradationProbability(t *testing.T) {
 	tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 	handler := &ClientSideProxyTrafficHandler{
 		tokenManager:          tokenManager,
+		expectedPlayerNumber:  1,
 		degradationPercentage: 50, // Drop 50% of packets
 		rng:                   rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
@@ -410,12 +454,14 @@ func TestClientSideProxyTrafficHandler_IndependentDegradation(t *testing.T) {
 
 	// Create two independent handlers
 	handler1 := &ClientSideProxyTrafficHandler{
-		tokenManager: tokenManager,
-		rng:          rand.New(rand.NewSource(time.Now().UnixMicro())),
+		tokenManager:         tokenManager,
+		expectedPlayerNumber: 1,
+		rng:                  rand.New(rand.NewSource(time.Now().UnixMicro())),
 	}
 	handler2 := &ClientSideProxyTrafficHandler{
-		tokenManager: tokenManager,
-		rng:          rand.New(rand.NewSource(time.Now().UnixMicro())),
+		tokenManager:         tokenManager,
+		expectedPlayerNumber: 1,
+		rng:                  rand.New(rand.NewSource(time.Now().UnixMicro())),
 	}
 
 	addr, _ := net.ResolveUDPAddr("udp", testutil.TestSourceAddr)
@@ -464,8 +510,9 @@ func TestClientSideProxyTrafficHandler_ParseConfigCommand_ListTokens(t *testing.
 		t.Run(tt.name, func(t *testing.T) {
 			tokenManager := token.NewTokenManager(tt.playerCount)
 			handler := &ClientSideProxyTrafficHandler{
-				tokenManager: tokenManager,
-				rng:          rand.New(rand.NewSource(time.Now().UnixNano())),
+				tokenManager:         tokenManager,
+				expectedPlayerNumber: 1,
+				rng:                  rand.New(rand.NewSource(time.Now().UnixNano())),
 			}
 
 			cmdName, err := handler.parseConfigCommand([]byte(tt.command))

--- a/player-gateway-testing-app/internal/proxy/proxy.go
+++ b/player-gateway-testing-app/internal/proxy/proxy.go
@@ -6,6 +6,7 @@ package proxy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -28,14 +29,15 @@ const (
 
 // Proxy handles UDP traffic forwarding between clients and a destination server.
 type Proxy struct {
-	port                 int                     // The port the proxy is listening on
-	socket               *net.UDPConn            // Main proxy socket for listening to game-bound traffic
-	destinationAddr      *net.UDPAddr            // Address to forward game-bound traffic to
-	clientConnectionPool *ClientConnectionPool   // Pool for each client connection that has connected via this proxy
-	forwardToPlayerChan  chan ClientBoundData    // Channel for forwarding player-bound traffic
-	trafficHandler       TrafficHandler          // Handler for traffic on client/server proxy
-	packetLogger         *PacketLogger           // Logger for failed packets
-	statsEventChan       chan<- stats.StatsEvent // Channel for publishing stats events
+	port                 int                          // The port the proxy is listening on
+	socket               *net.UDPConn                 // Main proxy socket for listening to game-bound traffic
+	destinationAddr      *net.UDPAddr                 // Address to forward game-bound traffic to
+	clientConnectionPool *ClientConnectionPool        // Pool for each client connection that has connected via this proxy
+	forwardToPlayerChan  chan ClientBoundData         // Channel for forwarding player-bound traffic
+	trafficHandler       TrafficHandler               // Handler for traffic on client/server proxy
+	packetLogger         *PacketLogger                // Logger for failed packets
+	statsEventChan       chan<- stats.StatsEvent      // Channel for publishing stats events
+	statsSnapshotFunc    func() stats.StatsSnapshot   // Function to get stats snapshot for connection details
 }
 
 // NewClientSideProxy creates a new proxy with a client-side traffic handler.
@@ -45,24 +47,28 @@ type Proxy struct {
 //   - port: port number for the proxy to listen on
 //   - destinationAddr: target address to forward incoming traffic to
 //   - tokenManager: token manager for validating and parsing tokens
+//   - expectedPlayerNumber: player number that must use this endpoint
 //   - reportFilePath: path to file for logging failed packets
 //   - statsEventChan: optional channel for publishing stats events (can be nil)
+//   - statsSnapshotFunc: optional function to get stats snapshot for connection details (can be nil)
 //
 // Returns:
 //   - *Proxy: configured client-side proxy ready to start
 //   - error: nil on success, error if socket creation fails
-func NewClientSideProxy(proxyIP string, port int, destinationAddr *net.UDPAddr, tokenManager *token.TokenManager, reportFilePath string, statsEventChan chan<- stats.StatsEvent) (*Proxy, error) {
+func NewClientSideProxy(proxyIP string, port int, destinationAddr *net.UDPAddr, tokenManager *token.TokenManager, expectedPlayerNumber int, reportFilePath string, statsEventChan chan<- stats.StatsEvent, statsSnapshotFunc func() stats.StatsSnapshot) (*Proxy, error) {
 	if tokenManager == nil {
 		return nil, fmt.Errorf("token manager is nil")
 	}
 	handler := &ClientSideProxyTrafficHandler{
-		tokenManager: tokenManager,
-		rng:          rand.New(rand.NewSource(time.Now().UnixNano())),
+		tokenManager:         tokenManager,
+		expectedPlayerNumber: expectedPlayerNumber,
+		rng:                  rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 	proxy, err := newProxy(proxyIP, port, destinationAddr, handler, reportFilePath, statsEventChan)
 	if err != nil {
 		return nil, err
 	}
+	proxy.statsSnapshotFunc = statsSnapshotFunc
 	return proxy, nil
 }
 
@@ -86,8 +92,8 @@ func NewServerSideProxy(proxyIP string, port int, destinationAddr *net.UDPAddr, 
 	handler := &ServerSideProxyTrafficHandler{
 		tokenManager:           tokenManager,
 		clientSideProxySources: make(map[int][]*ClientSideProxyInfo),
-		nextSourceIndexByPort:  make(map[int]int),
-		recentMessages:         make(map[int][]*net.UDPAddr),
+		lastUsedSource:         make(map[int]*ClientSideProxyInfo),
+		nextSourceIndex:        make(map[int]int),
 	}
 	proxy, err := newProxy(proxyIP, port, destinationAddr, handler, reportFilePath, statsEventChan)
 	if err != nil {
@@ -218,6 +224,17 @@ func (p *Proxy) handleIncomingTraffic(ctx context.Context, buf []byte) error {
 				DegradationPercent: deg.Percentage,
 			})
 		}
+		if details, ok := result.ConfigCommand.(GetPlayerConnectionDetailsResult); ok {
+			var response string
+			if p.statsSnapshotFunc == nil {
+				response = `{"error":"stats snapshot not available"}`
+			} else {
+				response = p.buildConnectionDetailsJSON(details.PlayerNumbers)
+			}
+			if _, err := p.socket.WriteToUDP([]byte(response), sourceAddr); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 
@@ -292,4 +309,61 @@ func (p *Proxy) Close() error {
 //   - net.Addr: local address of the proxy socket
 func (p *Proxy) LocalAddr() net.Addr {
 	return p.socket.LocalAddr()
+}
+
+const tokenExpirationMinutes = 3
+
+type PlayerConnectionDetailsResponse struct {
+	PlayerConnectionDetails []PlayerConnectionDetail `json:"PlayerConnectionDetails"`
+}
+
+type PlayerConnectionDetail struct {
+	PlayerNumber       string                     `json:"PlayerNumber"`
+	Endpoints          []PlayerConnectionEndpoint `json:"Endpoints"`
+	PlayerGatewayToken string                     `json:"PlayerGatewayToken"`
+	Expiration         int64                      `json:"Expiration"`
+}
+
+type PlayerConnectionEndpoint struct {
+	IpAddress string `json:"IpAddress"`
+	Port      int    `json:"Port"`
+}
+
+func (p *Proxy) buildConnectionDetailsJSON(playerNumbers []int) string {
+	snapshot := p.statsSnapshotFunc()
+
+	requestedNumbers := make(map[int]bool)
+	for _, num := range playerNumbers {
+		requestedNumbers[num] = true
+	}
+
+	expiration := time.Now().Add(tokenExpirationMinutes * time.Minute).Unix()
+	details := make([]PlayerConnectionDetail, 0)
+	for playerNum, ports := range snapshot.PlayerEndpoints {
+		if len(requestedNumbers) > 0 && !requestedNumbers[playerNum] {
+			continue
+		}
+
+		endpoints := make([]PlayerConnectionEndpoint, 0, len(ports))
+		for _, port := range ports {
+			endpoints = append(endpoints, PlayerConnectionEndpoint{
+				IpAddress: snapshot.IPAddress,
+				Port:      port,
+			})
+		}
+
+		details = append(details, PlayerConnectionDetail{
+			PlayerNumber:       strconv.Itoa(playerNum),
+			Endpoints:          endpoints,
+			PlayerGatewayToken: snapshot.ValidTokens[playerNum],
+			Expiration:         expiration,
+		})
+	}
+
+	response := PlayerConnectionDetailsResponse{
+		PlayerConnectionDetails: details,
+	}
+
+	jsonBytes, _ := json.Marshal(response)
+	return string(jsonBytes)
 }

--- a/player-gateway-testing-app/internal/proxy/proxy_test.go
+++ b/player-gateway-testing-app/internal/proxy/proxy_test.go
@@ -21,7 +21,7 @@ func TestNewClientSideProxy(t *testing.T) {
 	destinationAddr, _ := net.ResolveUDPAddr("udp", testutil.TestDestinationAddr)
 	tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 
-	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, destinationAddr, tokenManager, testutil.TestReportFilePath, nil)
+	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, destinationAddr, tokenManager, 1, testutil.TestReportFilePath, nil, nil)
 	assert.NoError(t, err)
 	defer proxy.Close()
 
@@ -35,7 +35,7 @@ func TestNewClientProxy_NilTokenManager(t *testing.T) {
 
 	destinationAddr, _ := net.ResolveUDPAddr("udp", testutil.TestDestinationAddr)
 
-	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, destinationAddr, nil, testutil.TestReportFilePath, nil)
+	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, destinationAddr, nil, 1, testutil.TestReportFilePath, nil, nil)
 	assert.Error(t, err, "Expected error but didn't receive one")
 	assert.Equal(t, proxy, (*Proxy)(nil), "Expected client-side proxy to be nil")
 }
@@ -71,7 +71,7 @@ func TestProxy_LocalAddr(t *testing.T) {
 	destinationAddr, _ := net.ResolveUDPAddr("udp", testutil.TestDestinationAddr)
 	tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 
-	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, destinationAddr, tokenManager, testutil.TestReportFilePath, nil)
+	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, destinationAddr, tokenManager, 1, testutil.TestReportFilePath, nil, nil)
 	assert.NoError(t, err)
 	defer proxy.Close()
 
@@ -89,7 +89,7 @@ func TestProxy_Close(t *testing.T) {
 	destinationAddr, _ := net.ResolveUDPAddr("udp", testutil.TestDestinationAddr)
 	tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 
-	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, destinationAddr, tokenManager, testutil.TestReportFilePath, nil)
+	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, destinationAddr, tokenManager, 1, testutil.TestReportFilePath, nil, nil)
 	assert.NoError(t, err)
 
 	err = proxy.Close()
@@ -102,7 +102,7 @@ func TestProxy_StartStop(t *testing.T) {
 	destinationAddr, _ := net.ResolveUDPAddr("udp", testutil.TestDestinationAddr)
 	tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 
-	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, destinationAddr, tokenManager, testutil.TestReportFilePath, nil)
+	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, destinationAddr, tokenManager, 1, testutil.TestReportFilePath, nil, nil)
 	assert.NoError(t, err)
 	defer proxy.Close()
 
@@ -133,7 +133,7 @@ func TestProxy_ClientCanSendAndReceiveThroughProxy(t *testing.T) {
 	tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 
 	// Create proxy
-	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, gameServer.LocalAddr().(*net.UDPAddr), tokenManager, testutil.TestReportFilePath, nil)
+	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, gameServer.LocalAddr().(*net.UDPAddr), tokenManager, 1, testutil.TestReportFilePath, nil, nil)
 	assert.NoError(t, err)
 	defer proxy.Close()
 
@@ -183,7 +183,7 @@ func TestProxy_Start_ContinuesOnPacketDropped(t *testing.T) {
 	destinationAddr, _ := net.ResolveUDPAddr("udp", testutil.TestDestinationAddr)
 	tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 
-	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, destinationAddr, tokenManager, testutil.TestReportFilePath, nil)
+	proxy, err := NewClientSideProxy(testutil.TestProxyAddr, 0, destinationAddr, tokenManager, 1, testutil.TestReportFilePath, nil, nil)
 	assert.NoError(t, err)
 	defer proxy.Close()
 

--- a/player-gateway-testing-app/internal/proxy/server_side_traffic_handler.go
+++ b/player-gateway-testing-app/internal/proxy/server_side_traffic_handler.go
@@ -12,12 +12,12 @@ import (
 )
 
 const (
-	// maxRecentMessages is the size of the buffer that tracks recent messages sent from client-side proxy for a given player.
-	// If a proxy hasn't sent a message in the last maxRecentMessages, it's considered stale and removed from the active sources list.
-	maxRecentMessages = 20
-	// sourceTimeoutDuration is the maximum time since last received traffic before a client-side
-	// proxy source is considered stale and removed from the active sources list
-	sourceTimeoutDuration = 30 * time.Second
+	// activeEndpointTimeout is how long an endpoint stays in the round-robin rotation
+	// after receiving traffic from the client
+	activeEndpointTimeout = 1 * time.Second
+	// connectionDropTimeout is how long before blocking all Server->Client traffic
+	// when no Client->Server traffic has been received
+	connectionDropTimeout = 60 * time.Second
 )
 
 // ClientSideProxyInfo holds information about a client-side proxy source that sent traffic.
@@ -30,8 +30,8 @@ type ClientSideProxyInfo struct {
 type ServerSideProxyTrafficHandler struct {
 	tokenManager           *token.TokenManager            // Token manager for parsing tokens
 	clientSideProxySources map[int][]*ClientSideProxyInfo // Player number -> client-side proxy sources info
-	nextSourceIndexByPort  map[int]int                    // Return traffic port -> index
-	recentMessages         map[int][]*net.UDPAddr         // Last maxRecentMessages addresses per player
+	lastUsedSource         map[int]*ClientSideProxyInfo   // Player number -> most recently used endpoint
+	nextSourceIndex        map[int]int                    // Player number -> round-robin index
 }
 
 // PreprocessServerBoundTraffic tracks client-side proxy sources and extracts player information.
@@ -46,7 +46,6 @@ type ServerSideProxyTrafficHandler struct {
 //   - PreprocessServerBoundTrafficResult: contains player number, modified data, and command result
 //   - error: nil on success, error if token parsing fails
 func (s *ServerSideProxyTrafficHandler) PreprocessServerBoundTraffic(data []byte, sourceAddr *net.UDPAddr) (PreprocessServerBoundTrafficResult, error) {
-	// Extract player number and strip entire token from data
 	playerNumber, modifiedData, err := s.tokenManager.ParseServerSideToken(data)
 	if err != nil {
 		return PreprocessServerBoundTrafficResult{0, nil, nil}, err
@@ -55,20 +54,18 @@ func (s *ServerSideProxyTrafficHandler) PreprocessServerBoundTraffic(data []byte
 	sources := s.clientSideProxySources[playerNumber]
 	clientInfo, exists := s.findClientInfo(sources, sourceAddr)
 	if !exists {
-		clientInfo = &ClientSideProxyInfo{
-			SourceAddr: sourceAddr,
-		}
+		clientInfo = &ClientSideProxyInfo{SourceAddr: sourceAddr}
 		s.clientSideProxySources[playerNumber] = append(sources, clientInfo)
 	}
 	clientInfo.LastReceivedTimestamp = time.Now()
-
-	s.addToRecentMessages(playerNumber, sourceAddr)
+	s.lastUsedSource[playerNumber] = clientInfo
 
 	return PreprocessServerBoundTrafficResult{playerNumber, modifiedData, nil}, nil
 }
 
-// HandleClientBoundTraffic distributes client-bound traffic across client-side proxies using round-robin.
-// Removes stale client-side proxies that haven't received traffic in the last sourceTimeoutDuration or sent a message in the last maxRecentMessages.
+// HandleClientBoundTraffic distributes client-bound traffic using round-robin across endpoints
+// active within the past activeEndpointTimeout. Falls back to most recently used endpoint if none active.
+// Blocks traffic and cleans up player state if no activity for connectionDropTimeout.
 //
 // Parameters:
 //   - data: the data to send to the client and the client connection port it was received on
@@ -83,35 +80,42 @@ func (s *ServerSideProxyTrafficHandler) HandleClientBoundTraffic(data ClientBoun
 		return nil
 	}
 
+	// Check connection drop timeout
+	lastUsed := s.lastUsedSource[playerNumber]
+	if lastUsed == nil || time.Since(lastUsed.LastReceivedTimestamp) >= connectionDropTimeout {
+		// Clean up stale player state
+		delete(s.clientSideProxySources, playerNumber)
+		delete(s.lastUsedSource, playerNumber)
+		delete(s.nextSourceIndex, playerNumber)
+		return nil // Block traffic
+	}
+
+	// Get active endpoints (within activeEndpointTimeout)
 	sources := s.clientSideProxySources[playerNumber]
-	if len(sources) == 0 {
-		return nil
+	activeSources := s.filterActiveSources(sources)
+
+	// Fall back to last used if no active endpoints
+	if len(activeSources) == 0 {
+		activeSources = []*ClientSideProxyInfo{lastUsed}
 	}
 
-	nextIndex := s.nextSourceIndexByPort[data.ClientConnectionPort]
-	sources = s.removeStaleSources(sources, nextIndex, playerNumber)
-	if nextIndex >= len(sources) {
-		nextIndex = 0
-	}
+	// Round-robin
+	idx := s.nextSourceIndex[playerNumber]
+	s.nextSourceIndex[playerNumber] = (idx + 1) % len(activeSources)
 
-	s.clientSideProxySources[playerNumber] = sources
-	s.nextSourceIndexByPort[data.ClientConnectionPort] = (nextIndex + 1) % len(sources)
-
-	if _, err := socket.WriteToUDP(data.Data, sources[nextIndex].SourceAddr); err != nil {
-		return err
-	}
-	return nil
+	_, err := socket.WriteToUDP(data.Data, activeSources[idx].SourceAddr)
+	return err
 }
 
-// findClientInfo finds an existing source and updates its timestamp.
+// findClientInfo finds an existing source in the sources slice.
 //
 // Parameters:
 //   - sources: slice of client-side proxy info to search through
-//   - sourceAddr: UDP address to find and update
+//   - sourceAddr: UDP address to find
 //
 // Returns:
 //   - *ClientSideProxyInfo: the client-side proxy info corresponding to the given sourceAddr if found
-//   - bool: true if source exists (and was updated), false if not found
+//   - bool: true if source exists, false if not found
 func (s *ServerSideProxyTrafficHandler) findClientInfo(sources []*ClientSideProxyInfo, sourceAddr *net.UDPAddr) (*ClientSideProxyInfo, bool) {
 	for _, info := range sources {
 		if info.SourceAddr.String() == sourceAddr.String() {
@@ -121,76 +125,19 @@ func (s *ServerSideProxyTrafficHandler) findClientInfo(sources []*ClientSideProx
 	return nil, false
 }
 
-// addToRecentMessages adds a source address to the recent messages ring buffer.
-// Maintains a maximum of maxRecentMessages entries per player.
+// filterActiveSources returns sources that have received traffic within activeEndpointTimeout.
 //
 // Parameters:
-//   - playerNumber: the player number
-//   - sourceAddr: the source address to add
-func (s *ServerSideProxyTrafficHandler) addToRecentMessages(playerNumber int, sourceAddr *net.UDPAddr) {
-	s.recentMessages[playerNumber] = append(s.recentMessages[playerNumber], sourceAddr)
-	if len(s.recentMessages[playerNumber]) > maxRecentMessages {
-		startIndex := len(s.recentMessages[playerNumber]) - maxRecentMessages
-		s.recentMessages[playerNumber] = s.recentMessages[playerNumber][startIndex:]
-	}
-}
-
-// removeStaleSources removes stale sources starting from the given index and returns the next valid source.
-// Keeps removing sources until it finds an active one or only one source remains.
-//
-// Parameters:
-//   - sources: slice of client-side proxy sources
-//   - index: index to start checking from
-//   - playerNumber: the player number
+//   - sources: slice of client-side proxy info to filter
 //
 // Returns:
-//   - []*ClientSideProxyInfo: updated sources slice with stale sources removed
-func (s *ServerSideProxyTrafficHandler) removeStaleSources(sources []*ClientSideProxyInfo, index int, playerNumber int) []*ClientSideProxyInfo {
-	clientInfo := sources[index]
-
-	for len(sources) > 1 {
-		if s.isSourceActive(playerNumber, clientInfo) {
-			break
-		}
-
-		sources = append(sources[:index], sources[index+1:]...)
-		if index >= len(sources) {
-			index = 0
-		}
-		clientInfo = sources[index]
-	}
-
-	return sources
-}
-
-// isSourceActive checks if a source is still active based on recent messages and timestamp.
-// A source is considered active if it has sent a message in the last maxRecentMessages
-// AND has received traffic in the past sourceTimeoutDuration.
-//
-// Parameters:
-//   - playerNumber: the player number
-//   - clientInfo: the client-side proxy info to check
-//
-// Returns:
-//   - bool: true if source is active, false if stale
-func (s *ServerSideProxyTrafficHandler) isSourceActive(playerNumber int, clientInfo *ClientSideProxyInfo) bool {
-	return s.isInRecentMessages(playerNumber, clientInfo.SourceAddr) &&
-		time.Since(clientInfo.LastReceivedTimestamp) < sourceTimeoutDuration
-}
-
-// isInRecentMessages checks if an address is in the last maxRecentMessages for a player.
-//
-// Parameters:
-//   - playerNumber: the player number to check
-//   - addr: the UDP address to search for
-//
-// Returns:
-//   - bool: true if address is found in the last maxRecentMessages, false otherwise
-func (s *ServerSideProxyTrafficHandler) isInRecentMessages(playerNumber int, addr *net.UDPAddr) bool {
-	for _, recentAddr := range s.recentMessages[playerNumber] {
-		if recentAddr.String() == addr.String() {
-			return true
+//   - []*ClientSideProxyInfo: slice containing only active sources
+func (s *ServerSideProxyTrafficHandler) filterActiveSources(sources []*ClientSideProxyInfo) []*ClientSideProxyInfo {
+	var active []*ClientSideProxyInfo
+	for _, src := range sources {
+		if time.Since(src.LastReceivedTimestamp) < activeEndpointTimeout {
+			active = append(active, src)
 		}
 	}
-	return false
+	return active
 }

--- a/player-gateway-testing-app/internal/proxy/server_side_traffic_handler_test.go
+++ b/player-gateway-testing-app/internal/proxy/server_side_traffic_handler_test.go
@@ -19,13 +19,61 @@ var (
 	testAddr3, _ = net.ResolveUDPAddr("udp", "127.0.0.1:3000")
 )
 
+type testSetup struct {
+	handler *ServerSideProxyTrafficHandler
+	socket  *net.UDPConn
+	ccPool  *ClientConnectionPool
+}
+
+func newTestSetup(t *testing.T) *testSetup {
+	socket := testutil.CreateTestUDPSocket(t)
+	t.Cleanup(func() { socket.Close() })
+
+	handler := &ServerSideProxyTrafficHandler{
+		clientSideProxySources: make(map[int][]*ClientSideProxyInfo),
+		lastUsedSource:         make(map[int]*ClientSideProxyInfo),
+		nextSourceIndex:        make(map[int]int),
+	}
+
+	ccPool := &ClientConnectionPool{clientConnectionPortMap: make(map[int]*ClientConnectionInfo)}
+	ccPool.clientConnectionPortMap[testutil.TestReturnTrafficPort] = &ClientConnectionInfo{PlayerNumber: testutil.TestPlayerNumber}
+
+	return &testSetup{handler: handler, socket: socket, ccPool: ccPool}
+}
+
+func (s *testSetup) addEndpoint(t *testing.T, age time.Duration) *net.UDPConn {
+	proxy := testutil.CreateTestUDPSocket(t)
+	t.Cleanup(func() { proxy.Close() })
+
+	info := &ClientSideProxyInfo{
+		SourceAddr:            proxy.LocalAddr().(*net.UDPAddr),
+		LastReceivedTimestamp: time.Now().Add(-age),
+	}
+	s.handler.clientSideProxySources[testutil.TestPlayerNumber] = append(
+		s.handler.clientSideProxySources[testutil.TestPlayerNumber], info)
+	s.handler.lastUsedSource[testutil.TestPlayerNumber] = info
+	return proxy
+}
+
+func (s *testSetup) send(msg string) error {
+	data := ClientBoundData{Data: []byte(msg), ClientConnectionPort: testutil.TestReturnTrafficPort}
+	return s.handler.HandleClientBoundTraffic(data, s.ccPool, s.socket)
+}
+
+func assertNoMessageReceived(t *testing.T, conn *net.UDPConn) {
+	conn.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	buf := make([]byte, 1024)
+	_, _, err := conn.ReadFromUDP(buf)
+	assert.True(t, err != nil, "Expected no message due to connectionDropTimeout")
+}
+
 func TestServerSideProxyTrafficHandler_PreprocessServerBoundTraffic(t *testing.T) {
 	tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 	handler := &ServerSideProxyTrafficHandler{
 		tokenManager:           tokenManager,
 		clientSideProxySources: make(map[int][]*ClientSideProxyInfo),
-		nextSourceIndexByPort:  make(map[int]int),
-		recentMessages:         make(map[int][]*net.UDPAddr),
+		lastUsedSource:         make(map[int]*ClientSideProxyInfo),
+		nextSourceIndex:        make(map[int]int),
 	}
 
 	// Create data with player number token (hash already stripped by client-side proxy)
@@ -43,288 +91,158 @@ func TestServerSideProxyTrafficHandler_PreprocessServerBoundTraffic(t *testing.T
 	// Verify source was added
 	sources := handler.clientSideProxySources[result.PlayerNumber]
 	assert.Equal(t, len(sources), 1)
+	assert.Equal(t, sources[0].SourceAddr.String(), sourceAddr.String())
 
+	// Verify timestamp was updated
 	clientLastReceivedTimestamp := handler.clientSideProxySources[testutil.TestPlayerNumber][0].LastReceivedTimestamp
 	assert.True(t, time.Since(clientLastReceivedTimestamp) <= time.Second, "Expected timestamp to be updated to recent time")
 
-	assert.Equal(t, sources[0].SourceAddr.String(), sourceAddr.String())
+	// Verify lastUsedSource was set
+	assert.Equal(t, handler.lastUsedSource[result.PlayerNumber].SourceAddr.String(), sourceAddr.String())
 
-	// Test duplicate source is not added
+	// Test duplicate source is not added but timestamp is refreshed
+	firstCallTimestamp := clientLastReceivedTimestamp
+	time.Sleep(10 * time.Millisecond)
 	_, err = handler.PreprocessServerBoundTraffic(data, sourceAddr)
 	assert.NoError(t, err)
+	assert.Equal(t, len(handler.clientSideProxySources[result.PlayerNumber]), 1)
 
-	sources = handler.clientSideProxySources[result.PlayerNumber]
-	assert.Equal(t, len(sources), 1)
+	// Verify timestamp was refreshed for duplicate source
+	secondCallTimestamp := handler.clientSideProxySources[result.PlayerNumber][0].LastReceivedTimestamp
+	assert.True(t, secondCallTimestamp.After(firstCallTimestamp), "Timestamp should be updated on duplicate source")
+	assert.Equal(t, handler.lastUsedSource[result.PlayerNumber].SourceAddr.String(), sourceAddr.String())
 }
 
 func TestServerSideProxyTrafficHandler_HandleClientBoundTraffic(t *testing.T) {
-	handler := &ServerSideProxyTrafficHandler{
-		clientSideProxySources: make(map[int][]*ClientSideProxyInfo),
-		nextSourceIndexByPort:  make(map[int]int),
-		recentMessages:         make(map[int][]*net.UDPAddr),
-	}
+	t.Run("RoundRobin", func(t *testing.T) {
+		s := newTestSetup(t)
+		proxy1 := s.addEndpoint(t, 0)
+		proxy2 := s.addEndpoint(t, 0)
 
-	socket := testutil.CreateTestUDPSocket(t)
-	defer socket.Close()
+		s.send(testutil.TestMessage)
+		msg, _ := testutil.ReadUDPMessage(t, proxy1)
+		assert.Equal(t, msg, testutil.TestMessage)
 
-	proxySocket := testutil.CreateTestUDPSocket(t)
-	defer proxySocket.Close()
+		s.send(testutil.TestMessage)
+		msg, _ = testutil.ReadUDPMessage(t, proxy2)
+		assert.Equal(t, msg, testutil.TestMessage)
+	})
 
-	proxyAddr := proxySocket.LocalAddr().(*net.UDPAddr)
+	t.Run("RoundRobinWrapsAround", func(t *testing.T) {
+		s := newTestSetup(t)
+		proxy1 := s.addEndpoint(t, 0)
+		proxy2 := s.addEndpoint(t, 0)
 
-	handler.clientSideProxySources[testutil.TestPlayerNumber] = []*ClientSideProxyInfo{
-		{
-			SourceAddr:            proxyAddr,
-			LastReceivedTimestamp: time.Now().Add(-100 * time.Second),
-		},
-	}
-	handler.recentMessages[testutil.TestPlayerNumber] = []*net.UDPAddr{proxyAddr}
+		// Send 4 messages - should cycle: proxy1, proxy2, proxy1, proxy2
+		s.send(testutil.TestMessage)
+		msg, _ := testutil.ReadUDPMessage(t, proxy1)
+		assert.Equal(t, msg, testutil.TestMessage)
 
-	ccPool := &ClientConnectionPool{
-		clientConnectionPortMap: make(map[int]*ClientConnectionInfo),
-	}
-	ccPool.clientConnectionPortMap[testutil.TestReturnTrafficPort] = &ClientConnectionInfo{
-		PlayerNumber: testutil.TestPlayerNumber,
-	}
+		s.send(testutil.TestMessage)
+		msg, _ = testutil.ReadUDPMessage(t, proxy2)
+		assert.Equal(t, msg, testutil.TestMessage)
 
-	data := ClientBoundData{
-		Data:                 []byte(testutil.TestMessage),
-		ClientConnectionPort: testutil.TestReturnTrafficPort,
-	}
+		s.send(testutil.TestMessage)
+		msg, _ = testutil.ReadUDPMessage(t, proxy1)
+		assert.Equal(t, msg, testutil.TestMessage)
 
-	// Test successful handling
-	err := handler.HandleClientBoundTraffic(data, ccPool, socket)
-	assert.NoError(t, err)
+		s.send(testutil.TestMessage)
+		msg, _ = testutil.ReadUDPMessage(t, proxy2)
+		assert.Equal(t, msg, testutil.TestMessage)
+	})
 
-	// Verify round robin index stays at 0 for single source
-	assert.Equal(t, handler.nextSourceIndexByPort[testutil.TestReturnTrafficPort], 0)
+	t.Run("FallbackToLastUsed", func(t *testing.T) {
+		s := newTestSetup(t)
+		proxy := s.addEndpoint(t, 5*time.Second) // stale for round-robin but within connectionDropTimeout
 
-	receivedString, _ := testutil.ReadUDPMessage(t, proxySocket)
-	assert.Equal(t, receivedString, string(testutil.TestMessage))
+		err := s.send("fallback")
+		assert.NoError(t, err)
 
-	// Test with no sources (should not error)
-	handler.clientSideProxySources[testutil.TestPlayerNumber] = []*ClientSideProxyInfo{}
-	err = handler.HandleClientBoundTraffic(data, ccPool, socket)
-	assert.NoError(t, err)
+		msg, _ := testutil.ReadUDPMessage(t, proxy)
+		assert.Equal(t, msg, "fallback")
+	})
+
+	t.Run("ConnectionDrop", func(t *testing.T) {
+		s := newTestSetup(t)
+		proxy := s.addEndpoint(t, 65*time.Second)
+
+		err := s.send("blocked")
+		assert.NoError(t, err)
+
+		assertNoMessageReceived(t, proxy)
+
+		_, sourcesExist := s.handler.clientSideProxySources[testutil.TestPlayerNumber]
+		_, lastUsedExists := s.handler.lastUsedSource[testutil.TestPlayerNumber]
+		_, indexExists := s.handler.nextSourceIndex[testutil.TestPlayerNumber]
+		assert.True(t, !sourcesExist, "clientSideProxySources should be cleaned up")
+		assert.True(t, !lastUsedExists, "lastUsedSource should be cleaned up")
+		assert.True(t, !indexExists, "nextSourceIndex should be cleaned up")
+	})
+
+	t.Run("EndpointBecomesStale", func(t *testing.T) {
+		s := newTestSetup(t)
+		s.addEndpoint(t, 2*time.Second) // stale (>1s)
+		proxy2 := s.addEndpoint(t, 0)   // active
+
+		// Both messages should go to proxy2 (only active endpoint)
+		s.send(testutil.TestMessage)
+		msg, _ := testutil.ReadUDPMessage(t, proxy2)
+		assert.Equal(t, msg, testutil.TestMessage)
+
+		s.send(testutil.TestMessage)
+		msg, _ = testutil.ReadUDPMessage(t, proxy2)
+		assert.Equal(t, msg, testutil.TestMessage)
+	})
+
+	t.Run("ConnectionRestoredAfterDrop", func(t *testing.T) {
+		tokenManager := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
+		s := newTestSetup(t)
+		s.handler.tokenManager = tokenManager
+		proxy := s.addEndpoint(t, 65*time.Second)
+
+		s.send("blocked")
+		assertNoMessageReceived(t, proxy)
+
+		// Client sends a message - this updates lastUsedSource timestamp
+		clientData := []byte("1|hello")
+		s.handler.PreprocessServerBoundTraffic(clientData, proxy.LocalAddr().(*net.UDPAddr))
+
+		s.send("restored")
+
+		proxy.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		msg, _ := testutil.ReadUDPMessage(t, proxy)
+		assert.Equal(t, msg, "restored")
+	})
 }
 
 func TestServerSideProxyTrafficHandler_FindClientInfo(t *testing.T) {
+	handler := &ServerSideProxyTrafficHandler{}
 
-	tests := []struct {
-		name          string
-		sources       []*ClientSideProxyInfo
-		searchAddr    *net.UDPAddr
-		expectedFound bool
-	}{
-		{
-			name: "find existing source",
-			sources: []*ClientSideProxyInfo{
-				{SourceAddr: testAddr1, LastReceivedTimestamp: time.Now().Add(-10 * time.Second)},
-				{SourceAddr: testAddr2, LastReceivedTimestamp: time.Now().Add(-5 * time.Second)},
-			},
-			searchAddr:    testAddr1,
-			expectedFound: true,
-		},
-		{
-			name: "not finding non-existent source",
-			sources: []*ClientSideProxyInfo{
-				{SourceAddr: testAddr1, LastReceivedTimestamp: time.Now().Add(-10 * time.Second)},
-				{SourceAddr: testAddr2, LastReceivedTimestamp: time.Now().Add(-5 * time.Second)},
-			},
-			searchAddr:    testAddr3,
-			expectedFound: false,
-		},
+	sources := []*ClientSideProxyInfo{
+		{SourceAddr: testAddr1},
+		{SourceAddr: testAddr2},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			handler := &ServerSideProxyTrafficHandler{}
-			_, found := handler.findClientInfo(tt.sources, tt.searchAddr)
+	info, found := handler.findClientInfo(sources, testAddr1)
+	assert.True(t, found, "Should find existing source")
+	assert.Equal(t, info.SourceAddr.String(), testAddr1.String())
 
-			assert.Equal(t, found, tt.expectedFound)
-		})
-	}
+	_, found = handler.findClientInfo(sources, testAddr3)
+	assert.True(t, !found, "Should not find non-existent source")
 }
 
-func TestServerSideProxyTrafficHandler_AddToRecentMessages(t *testing.T) {
-	handler := &ServerSideProxyTrafficHandler{
-		recentMessages: make(map[int][]*net.UDPAddr),
+func TestServerSideProxyTrafficHandler_FilterActiveSources(t *testing.T) {
+	handler := &ServerSideProxyTrafficHandler{}
+
+	now := time.Now()
+	sources := []*ClientSideProxyInfo{
+		{SourceAddr: testAddr1, LastReceivedTimestamp: now},                              // active
+		{SourceAddr: testAddr2, LastReceivedTimestamp: now.Add(-2 * time.Second)},        // stale
+		{SourceAddr: testAddr3, LastReceivedTimestamp: now.Add(-500 * time.Millisecond)}, // active
 	}
 
-	// Add first message
-	handler.addToRecentMessages(testutil.TestPlayerNumber, testAddr1)
-	assert.Equal(t, len(handler.recentMessages[testutil.TestPlayerNumber]), 1)
-
-	// Add more messages up to the limit
-	for i := 0; i < 19; i++ {
-		handler.addToRecentMessages(testutil.TestPlayerNumber, testAddr2)
-	}
-
-	assert.Equal(t, len(handler.recentMessages[testutil.TestPlayerNumber]), 20)
-
-	// Add one more to trigger trimming
-	handler.addToRecentMessages(testutil.TestPlayerNumber, testAddr1)
-	assert.Equal(t, len(handler.recentMessages[testutil.TestPlayerNumber]), 20)
-
-	// Verify oldest message was removed (first testAddr1 should be gone)
-	assert.Equal(t, handler.recentMessages[testutil.TestPlayerNumber][0].String(), testAddr2.String())
-}
-
-func TestServerSideProxyTrafficHandler_IsInRecentMessages(t *testing.T) {
-	tests := []struct {
-		name           string
-		recentMessages map[int][]*net.UDPAddr
-		playerNumber   int
-		searchAddr     *net.UDPAddr
-		expectedFound  bool
-	}{
-		{
-			name:           "find existing address addr1",
-			recentMessages: map[int][]*net.UDPAddr{testutil.TestPlayerNumber: {testAddr1, testAddr2}},
-			playerNumber:   testutil.TestPlayerNumber,
-			searchAddr:     testAddr1,
-			expectedFound:  true,
-		},
-		{
-			name:           "find existing address addr2",
-			recentMessages: map[int][]*net.UDPAddr{testutil.TestPlayerNumber: {testAddr1, testAddr2}},
-			playerNumber:   testutil.TestPlayerNumber,
-			searchAddr:     testAddr2,
-			expectedFound:  true,
-		},
-		{
-			name:           "not finding non-existent address",
-			recentMessages: map[int][]*net.UDPAddr{testutil.TestPlayerNumber: {testAddr1, testAddr2}},
-			playerNumber:   testutil.TestPlayerNumber,
-			searchAddr:     testAddr3,
-			expectedFound:  false,
-		},
-		{
-			name:           "empty recent messages for non-existent player",
-			recentMessages: map[int][]*net.UDPAddr{testutil.TestPlayerNumber: {testAddr1, testAddr2}},
-			playerNumber:   999,
-			searchAddr:     testAddr1,
-			expectedFound:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			handler := &ServerSideProxyTrafficHandler{
-				recentMessages: tt.recentMessages,
-			}
-
-			found := handler.isInRecentMessages(tt.playerNumber, tt.searchAddr)
-			assert.Equal(t, found, tt.expectedFound)
-		})
-	}
-}
-
-func TestServerSideProxyTrafficHandler_IsSourceActive(t *testing.T) {
-	tests := []struct {
-		name           string
-		recentMessages []*net.UDPAddr
-		clientInfo     *ClientSideProxyInfo
-		expectedActive bool
-	}{
-		{
-			name:           "active source - in recent messages and recent timestamp",
-			recentMessages: []*net.UDPAddr{testAddr1},
-			clientInfo: &ClientSideProxyInfo{
-				SourceAddr:            testAddr1,
-				LastReceivedTimestamp: time.Now(),
-			},
-			expectedActive: true,
-		},
-		{
-			name:           "inactive source - not in recent messages",
-			recentMessages: []*net.UDPAddr{testAddr1},
-			clientInfo: &ClientSideProxyInfo{
-				SourceAddr:            testAddr2,
-				LastReceivedTimestamp: time.Now(),
-			},
-			expectedActive: false,
-		},
-		{
-			name:           "inactive source - old timestamp",
-			recentMessages: []*net.UDPAddr{testAddr1},
-			clientInfo: &ClientSideProxyInfo{
-				SourceAddr:            testAddr1,
-				LastReceivedTimestamp: time.Now().Add(-35 * time.Second),
-			},
-			expectedActive: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			handler := &ServerSideProxyTrafficHandler{
-				recentMessages: map[int][]*net.UDPAddr{testutil.TestPlayerNumber: tt.recentMessages},
-			}
-
-			active := handler.isSourceActive(testutil.TestPlayerNumber, tt.clientInfo)
-			assert.Equal(t, active, tt.expectedActive)
-		})
-	}
-}
-
-func TestServerSideProxyTrafficHandler_RemoveStaleSources(t *testing.T) {
-	tests := []struct {
-		name                string
-		recentMessages      []*net.UDPAddr
-		sources             []*ClientSideProxyInfo
-		startIndex          int
-		expectedSourceCount int
-		expectedFirstAddr   string
-	}{
-		{
-			name:           "remove stale source at index 0",
-			recentMessages: []*net.UDPAddr{testAddr2, testAddr3},
-			sources: []*ClientSideProxyInfo{
-				{SourceAddr: testAddr1, LastReceivedTimestamp: time.Now().Add(-35 * time.Second)},
-				{SourceAddr: testAddr2, LastReceivedTimestamp: time.Now()},
-				{SourceAddr: testAddr3, LastReceivedTimestamp: time.Now()},
-			},
-			startIndex:          0,
-			expectedSourceCount: 2,
-			expectedFirstAddr:   testAddr2.String(),
-		},
-		{
-			name:           "all active sources - no removal",
-			recentMessages: []*net.UDPAddr{testAddr2, testAddr3},
-			sources: []*ClientSideProxyInfo{
-				{SourceAddr: testAddr2, LastReceivedTimestamp: time.Now()},
-				{SourceAddr: testAddr3, LastReceivedTimestamp: time.Now()},
-			},
-			startIndex:          1,
-			expectedSourceCount: 2,
-			expectedFirstAddr:   testAddr2.String(),
-		},
-		{
-			name:           "single stale source - should not remove",
-			recentMessages: []*net.UDPAddr{},
-			sources: []*ClientSideProxyInfo{
-				{SourceAddr: testAddr1, LastReceivedTimestamp: time.Now().Add(-31 * time.Second)},
-			},
-			startIndex:          0,
-			expectedSourceCount: 1,
-			expectedFirstAddr:   testAddr1.String(),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			handler := &ServerSideProxyTrafficHandler{
-				recentMessages: map[int][]*net.UDPAddr{testutil.TestPlayerNumber: tt.recentMessages},
-			}
-
-			updatedSources := handler.removeStaleSources(tt.sources, tt.startIndex, testutil.TestPlayerNumber)
-
-			assert.Equal(t, len(updatedSources), tt.expectedSourceCount)
-
-			if len(updatedSources) > 0 {
-				assert.Equal(t, updatedSources[0].SourceAddr.String(), tt.expectedFirstAddr)
-			}
-		})
-	}
+	active := handler.filterActiveSources(sources)
+	assert.Equal(t, len(active), 2)
+	assert.Equal(t, active[0].SourceAddr.String(), testAddr1.String())
+	assert.Equal(t, active[1].SourceAddr.String(), testAddr3.String())
 }

--- a/player-gateway-testing-app/internal/proxy/traffic_handler.go
+++ b/player-gateway-testing-app/internal/proxy/traffic_handler.go
@@ -39,3 +39,10 @@ func (d DegradationResult) ConfigCommandResult() {}
 type GenericCommandResult struct{}
 
 func (g GenericCommandResult) ConfigCommandResult() {}
+
+// GetPlayerConnectionDetailsResult contains the player numbers requested
+type GetPlayerConnectionDetailsResult struct {
+	PlayerNumbers []int
+}
+
+func (g GetPlayerConnectionDetailsResult) ConfigCommandResult() {}

--- a/player-gateway-testing-app/internal/renderer/renderer.go
+++ b/player-gateway-testing-app/internal/renderer/renderer.go
@@ -53,6 +53,7 @@ func NewModel(statsCollector *stats.StatsCollector, cancelFunc context.CancelFun
 		return nil, fmt.Errorf("StatsCollector is nil")
 	}
 	endpointColumns := []table.Column{
+		{Title: "Player", Width: 6},
 		{Title: "Endpoint", Width: 10},
 		{Title: "Port", Width: 5},
 		{Title: "Packets with Valid Token", Width: 25},
@@ -62,7 +63,7 @@ func NewModel(statsCollector *stats.StatsCollector, cancelFunc context.CancelFun
 
 	endpointTable := table.New(
 		table.WithColumns(endpointColumns),
-		table.WithHeight(12),
+		table.WithHeight(13),
 	)
 
 	s := table.DefaultStyles()
@@ -114,11 +115,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case TickMsg:
 		m.snapshot = m.statsCollector.GetSnapshot()
 
+		// Calculate endpoints per player from the snapshot
+		endpointsPerPlayer := 0
+		if len(m.snapshot.PlayerEndpoints) > 0 {
+			endpointsPerPlayer = len(m.snapshot.PlayerEndpoints[1])
+		}
+
 		// Update table rows and packet totals
 		var endpointRows []table.Row
 		var totalValidPackets, totalMalformedPackets int64
 		for i := range m.snapshot.EndpointStats {
+			// Only show player number on first endpoint for that player
+			playerStr := ""
+			if endpointsPerPlayer > 0 && i%endpointsPerPlayer == 0 {
+				playerStr = fmt.Sprintf("%d", i/endpointsPerPlayer+1)
+			}
+
 			endpointRows = append(endpointRows, table.Row{
+				playerStr,
 				fmt.Sprintf("%d", i+1),
 				fmt.Sprintf("%d", m.snapshot.EndpointStats[i].Port),
 				fmt.Sprintf("%d", m.snapshot.EndpointStats[i].ValidPackets),

--- a/player-gateway-testing-app/internal/renderer/renderer_test.go
+++ b/player-gateway-testing-app/internal/renderer/renderer_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNewModel(t *testing.T) {
-	statsCollector := stats.NewStatsCollector(nil, 8000, 3, "127.0.0.1")
+	statsCollector := stats.NewStatsCollector(nil, 8000, 3, 1, "127.0.0.1")
 	_, cancel := context.WithCancel(context.Background())
 
 	model, err := NewModel(statsCollector, cancel)

--- a/player-gateway-testing-app/internal/stats/stats.go
+++ b/player-gateway-testing-app/internal/stats/stats.go
@@ -33,11 +33,12 @@ type StatsEvent struct {
 
 // StatsSnapshot represents an immutable snapshot of current metrics
 type StatsSnapshot struct {
-	Uptime            time.Duration  // Total uptime of application
-	IPAddress         string         // IP address the testing app is bound to
-	EndpointStats     []ProxyStats   // List of stats per proxy
-	PlayerConnections map[int]bool   // Player number -> connected
-	ValidTokens       map[int]string // Player number -> base64-encoded token
+	Uptime            time.Duration    // Total uptime of application
+	IPAddress         string           // IP address the testing app is bound to
+	EndpointStats     []ProxyStats     // List of stats per proxy
+	PlayerConnections map[int]bool     // Player number -> connected
+	ValidTokens       map[int]string   // Player number -> base64-encoded token
+	PlayerEndpoints   map[int][]int    // Player number -> list of endpoint ports
 }
 
 // StatsCollector aggregates statistics events from proxy components
@@ -48,6 +49,7 @@ type StatsCollector struct {
 	playerConnections map[int]bool        // player number -> active connection
 	tokenManager      *token.TokenManager // token manager used to get info about valid tokens
 	eventChan         chan StatsEvent     // channel for receiving events from publishers
+	playerEndpoints   map[int][]int       // player number -> list of endpoint ports
 	mu                sync.RWMutex
 }
 
@@ -56,15 +58,23 @@ type StatsCollector struct {
 // Parameters:
 //   - tokenManager: token manager used to retrieve valid token information
 //   - startPort: starting port number for proxy endpoints
-//   - endpointCount: number of proxy endpoints to initialize stats for
+//   - endpointCount: number of UDP endpoints per player
+//   - playerCount: number of players
 //   - ipAddress: IP address the testing app is bound to
 //
 // Returns:
 //   - *StatsCollector: configured stats collector ready to start
-func NewStatsCollector(tokenManager *token.TokenManager, startPort, endpointCount int, ipAddress string) *StatsCollector {
+func NewStatsCollector(tokenManager *token.TokenManager, startPort, endpointCount, playerCount int, ipAddress string) *StatsCollector {
 	endpointStats := make(map[int]*ProxyStats)
-	for i := range endpointCount {
-		endpointStats[startPort+i] = &ProxyStats{Port: startPort + i}
+	playerEndpoints := make(map[int][]int)
+
+	port := startPort
+	for playerNum := 1; playerNum <= playerCount; playerNum++ {
+		for range endpointCount {
+			endpointStats[port] = &ProxyStats{Port: port}
+			playerEndpoints[playerNum] = append(playerEndpoints[playerNum], port)
+			port++
+		}
 	}
 
 	return &StatsCollector{
@@ -74,6 +84,7 @@ func NewStatsCollector(tokenManager *token.TokenManager, startPort, endpointCoun
 		playerConnections: make(map[int]bool),
 		tokenManager:      tokenManager,
 		eventChan:         make(chan StatsEvent, 100),
+		playerEndpoints:   playerEndpoints,
 	}
 }
 
@@ -210,6 +221,13 @@ func (sc *StatsCollector) GetSnapshot() StatsSnapshot {
 		playerConnectionsCopy[playerNum] = connected
 	}
 
+	playerEndpointsCopy := make(map[int][]int, len(sc.playerEndpoints))
+	for playerNum, ports := range sc.playerEndpoints {
+		portsCopy := make([]int, len(ports))
+		copy(portsCopy, ports)
+		playerEndpointsCopy[playerNum] = portsCopy
+	}
+
 	var validTokens map[int]string
 	if sc.tokenManager != nil {
 		validTokens = sc.tokenManager.GetValidTokens()
@@ -221,5 +239,6 @@ func (sc *StatsCollector) GetSnapshot() StatsSnapshot {
 		EndpointStats:     endpointStatsCopy,
 		PlayerConnections: playerConnectionsCopy,
 		ValidTokens:       validTokens,
+		PlayerEndpoints:   playerEndpointsCopy,
 	}
 }

--- a/player-gateway-testing-app/internal/stats/stats_test.go
+++ b/player-gateway-testing-app/internal/stats/stats_test.go
@@ -20,7 +20,7 @@ const (
 func TestStatsCollector_EventProcessing(t *testing.T) {
 	tm := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
 
-	collector := NewStatsCollector(tm, StartPort, 3, "127.0.0.1")
+	collector := NewStatsCollector(tm, StartPort, 3, 1, "127.0.0.1")
 
 	// Test EventPacketProcessed
 	collector.processEvent(StatsEvent{Type: EventValidPacketProcessed, Port: 8080})
@@ -58,7 +58,7 @@ func TestStatsCollector_EventProcessing(t *testing.T) {
 
 func TestStatsCollector_ConcurrentEventPublishing(t *testing.T) {
 	tm := testutil.CreateTestTokenManager(testutil.TestPlayerCount)
-	collector := NewStatsCollector(tm, StartPort, 10, "127.0.0.1")
+	collector := NewStatsCollector(tm, StartPort, 10, 1, "127.0.0.1")
 
 	// Start the collector
 	ctx := t.Context()
@@ -102,7 +102,7 @@ func TestStatsCollector_ConcurrentEventPublishing(t *testing.T) {
 
 func TestStatsCollector_SnapshotAccuracy(t *testing.T) {
 	tm := testutil.CreateTestTokenManager(2) // 2 players = 2 tokens
-	collector := NewStatsCollector(tm, StartPort, 2, "127.0.0.1")
+	collector := NewStatsCollector(tm, StartPort, 1, 2, "127.0.0.1")
 
 	// Add some events
 	collector.processEvent(StatsEvent{Type: EventValidPacketProcessed, Port: 8080})
@@ -126,30 +126,50 @@ func TestStatsCollector_SnapshotAccuracy(t *testing.T) {
 	assert.True(t, snapshot.Uptime > 0, "Expected positive uptime")
 }
 
+func TestStatsCollector_PlayerEndpoints(t *testing.T) {
+	tm := testutil.CreateTestTokenManager(3)
+	collector := NewStatsCollector(tm, StartPort, 2, 3, "127.0.0.1")
+
+	snapshot := collector.GetSnapshot()
+
+	// Verify per-player endpoint mapping
+	assert.Equal(t, len(snapshot.PlayerEndpoints), 3, "Expected 3 players")
+	assert.Equal(t, len(snapshot.PlayerEndpoints[1]), 2, "Player 1 should have 2 endpoints")
+	assert.Equal(t, snapshot.PlayerEndpoints[1][0], 8080, "Player 1 first port should be 8080")
+	assert.Equal(t, snapshot.PlayerEndpoints[1][1], 8081, "Player 1 second port should be 8081")
+	assert.Equal(t, snapshot.PlayerEndpoints[2][0], 8082, "Player 2 first port should be 8082")
+	assert.Equal(t, snapshot.PlayerEndpoints[2][1], 8083, "Player 2 second port should be 8083")
+	assert.Equal(t, snapshot.PlayerEndpoints[3][0], 8084, "Player 3 first port should be 8084")
+	assert.Equal(t, snapshot.PlayerEndpoints[3][1], 8085, "Player 3 second port should be 8085")
+
+	// Verify total endpoints
+	assert.Equal(t, len(snapshot.EndpointStats), 6, "Expected 6 total endpoints")
+}
+
 func TestStatsCollector_EdgeCases(t *testing.T) {
 	t.Run("zero connections", func(t *testing.T) {
-		collector := NewStatsCollector(nil, StartPort, 1, "127.0.0.1")
+		collector := NewStatsCollector(nil, StartPort, 1, 1, "127.0.0.1")
 		snapshot := collector.GetSnapshot()
 
 		assert.Equal(t, len(snapshot.PlayerConnections), 0, "Expected 0 connections")
 	})
 
 	t.Run("no endpoints", func(t *testing.T) {
-		collector := NewStatsCollector(nil, StartPort, 0, "127.0.0.1")
+		collector := NewStatsCollector(nil, StartPort, 0, 1, "127.0.0.1")
 		snapshot := collector.GetSnapshot()
 
 		assert.Equal(t, len(snapshot.EndpointStats), 0, "Expected 0 endpoints")
 	})
 
 	t.Run("nil token manager", func(t *testing.T) {
-		collector := NewStatsCollector(nil, StartPort, 1, "127.0.0.1")
+		collector := NewStatsCollector(nil, StartPort, 1, 1, "127.0.0.1")
 		snapshot := collector.GetSnapshot()
 
 		assert.Equal(t, len(snapshot.ValidTokens), 0, "Expected empty token list")
 	})
 
 	t.Run("update stats for port that doesn't have a proxy", func(t *testing.T) {
-		collector := NewStatsCollector(nil, StartPort, 1, "127.0.0.1")
+		collector := NewStatsCollector(nil, StartPort, 1, 1, "127.0.0.1")
 		collector.processEvent(StatsEvent{Type: EventValidPacketProcessed, Port: 9000})
 		collector.processEvent(StatsEvent{Type: EventMalformedPacketProcessed, Port: 9000})
 		collector.processEvent(StatsEvent{Type: EventPlayerConnected, PlayerNumber: 1})


### PR DESCRIPTION
Create endpoints for each player
Add round-robin communication from server to client
Add 1s timeout for an endpoint to be dropped
Add 60s timeout for server to client communication to be blocked
Add get-player-connection-details-command